### PR TITLE
docs: reforçar padrões arquiteturais

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SPEC-1 — English AI Tutor (Lean Spec)
 
-> Escopo desta versão: Documento enxuto, só com decisões de alto nível — requisitos funcionais e não funcionais, stack e metodologia (DDD + Clean Architecture + APA). Sem modelos de banco, algoritmos, prompts ou detalhes de implementação.
+> Escopo desta versão: Documento enxuto, só com decisões de alto nível — requisitos funcionais e não funcionais, stack e metodologia (DDD + SOLID + Clean Architecture + APA). Sem modelos de banco, algoritmos, prompts ou detalhes de implementação.
 
 ---
 
@@ -117,6 +117,9 @@ Adapters → Infra (DB, S3, LLM, ASR)
 - **Domain‑Driven Design (DDD):**
   - Modelar **bounded contexts** citados acima; linguagem ubíqua centrada em **entrevistas de TI** e **lições APA**.
   - Manter **regra de domínio** fora de controladores/adapters.
+- **Princípios SOLID:**
+  - Aplicar responsabilidade única em entidades, casos de uso e adapters.
+  - Favorecer inversão de dependência através de interfaces e contratos claros entre camadas.
 - **Clean Architecture:**
   - Dependências **de fora para dentro** apenas por **interfaces** (ports). Gateways para LLM/ASR/Storage **trocáveis**.
   - Testes de unidade no domínio/casos de uso; contratos para adapters.

--- a/doc/codex-notes.md
+++ b/doc/codex-notes.md
@@ -1,5 +1,15 @@
 # Codex Notes
 
+## Guidelines de Desenvolvimento
+
+- Projetar o sistema seguindo **Domain-Driven Design (DDD)**, mantendo regras de negócio encapsuladas no domínio e garantindo linguagem ubíqua alinhada aos bounded contexts descritos na SPEC-1.
+- Aplicar os princípios **SOLID** em serviços, entidades, casos de uso e adapters para preservar baixo acoplamento e alta coesão.
+- Estruturar as camadas conforme a **Clean Architecture**, com dependências fluindo das camadas externas para as internas apenas via interfaces e contratos explícitos.
+- Priorizar testes automatizados para o domínio e casos de uso, utilizando stubs/mocks para portar comportamentos das camadas externas.
+- Registrar decisões arquiteturais relevantes em ADRs quando aplicável e manter documentação atualizada no repositório.
+
+## Fluxo de Trabalho
+
 - Ao final de cada tarefa, executar o script `pnpm precommit:check`.
 - Caso o script reporte erros, corrigir antes de prosseguir.
 - Após corrigir, sugerir a mensagem de commit apropriada e aguardar a confirmação do usuário antes de executar o commit.


### PR DESCRIPTION
## Summary
- enfatiza o uso de DDD, SOLID e Clean Architecture na SPEC-1 do README
- adiciona guidelines de desenvolvimento ao doc/codex-notes.md

## Testing
- CI=1 pnpm precommit:check

------
https://chatgpt.com/codex/tasks/task_e_6903d6792e0883258fed5f5beca6a811